### PR TITLE
docs(maintainers): add maintainers guidelines and roles

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,300 @@
+# Maintainers
+
+Our goal is to ensure the long-term viability and continuous improvement of this
+project. To achieve this, we've established a clear and structured process for
+adding new maintainers and defining their roles and responsibilities. We believe
+in fostering a collaborative environment where diverse contributions are
+recognized and valued.
+
+## Becoming a Maintainer
+
+> [!NOTE]
+>
+> At this time, we are not accepting new Maintainers or Junior Maintainers. See
+> **“[Current Maintainers](#current-maintainers)”** for details.
+
+If you're interested in contributing to the project's long-term success by
+becoming a maintainer, you'll need to demonstrate a history of sustained and
+meaningful contributions. These contributions are crucial for showcasing your
+commitment and understanding of the project's codebase and community guidelines.
+
+Your contributions can include, but are not limited to:
+
+- **Pull Request Reviews**: Actively reviewing existing Pull Requests, providing
+  constructive feedback, suggesting improvements, and helping to ensure code
+  quality and adherence to project standards. Your insights help streamline the
+  merge process and enhance the overall reliability of the project.
+- **Code Contributions**: Submitting your own Pull Requests that introduce new
+  features, resolve reported bugs, improve existing functionalities, or enhance
+  documentation. High-quality code contributions demonstrate your technical
+  proficiency and ability to integrate new solutions effectively.
+- **Issue Management**: Participating in the discussion and resolution of
+  reported issues, **including reproducing bugs or validating fixes**, providing
+  support to other users, and helping to categorize and prioritize tasks.
+- **Community Engagement**: Actively participating in project discussions,
+  offering guidance to new contributors, and generally fostering a positive and
+  welcoming community environment.
+
+While your contributions don't need to be extensive in scale, consistency and
+quality are key. We value a steady commitment to the project over infrequent,
+large contributions.
+
+### Process to Become a Junior Maintainer
+
+1. Accumulate a clear record of ongoing, valuable contributions to the project,
+   aligning with the types of contributions outlined above.
+2. Create a Pull Request to add your GitHub handle and a direct link to your
+   GitHub profile under the "Current Maintainers" section in this [MAINTAINERS]
+   document, indicating your aspiration to be a Junior Maintainer. **Ensure your
+   Pull Request description clearly outlines your motivations and highlights
+   your most significant contributions.**
+3. The existing maintainers will thoroughly review your submitted Pull Request,
+   assess your past contributions, and engage in an internal discussion
+   regarding your nomination. During this phase, they may reach out for further
+   clarification or discussion.
+4. Upon successful approval, your Pull Request will be merged. At this point,
+   you will officially be granted the **Junior Maintainer** role, along with the
+   necessary permissions and responsibilities.
+
+## Maintainer Progression
+
+The process described above is the entry point for becoming a **Junior
+Maintainer**. Promotion to **Maintainer** and subsequently to **Senior
+Maintainer** is handled differently. These roles are granted based on merit,
+demonstrated expertise, consistent contributions, and trust earned within the
+project.
+
+Progression to a higher role is an internal process, initiated by existing
+Maintainers or the Project Founder, and does not require a new Pull Request from
+the candidate. It is a recognition of sustained commitment and leadership.
+
+### How Promotion Works
+
+- **Junior Maintainer** → **Maintainer**: Promotion occurs based on sustained
+  contributions and leadership. The existing maintainers will discuss and
+  nominate candidates for promotion, and the Project Founder will make the final
+  decision.
+- **Maintainer** → **Senior Maintainer**: Senior Maintainers are trusted leaders
+  with deep expertise in the project. This promotion is initiated by existing
+  Senior Maintainers or the Project Founder and reflects a candidate's ongoing
+  commitment, technical acumen, and ability to mentor others.
+
+## Maintainer Roles and Responsibilities
+
+To ensure clear ownership and efficient project management, we categorize
+maintainer roles with distinct responsibilities.
+
+### Project Founder
+
+- **Role**: The initial creator and ultimate decision-maker of the project. The
+  founder establishes the project's vision and direction.
+- **Responsibilities**:
+  - Defining the project's **strategic direction** and **vision**.
+  - Making **final decisions** on major changes and features.
+  - Appointing and dismissing other project roles (Maintainers, etc.).
+  - Overseeing the **overall health** and sustainability of the project.
+
+### Senior Maintainer
+
+- **Role**: Highly experienced contributors with deep knowledge of the codebase
+  and project goals. They hold primary responsibility for technical quality and
+  coordination.
+- **Responsibilities**:
+  - Performing **in-depth code reviews** and approving major pull requests.
+  - Making **technical architecture decisions**.
+  - **Coordinating releases** and version management.
+  - **Guiding and mentoring** other Maintainers and contributors, including
+    Junior Maintainers.
+  - Managing complex **technical issues** and disputes.
+  - Actively contributing to the **project roadmap**.
+
+### Maintainer
+
+- **Role**: Experienced contributors responsible for specific parts of the
+  project or for regular, day-to-day tasks.
+- **Responsibilities**:
+  - Performing **code reviews** and merging pull requests.
+  - Implementing **bugfixes** and new features according to project guidelines.
+  - **Maintaining and improving documentation**.
+  - Managing **issues and discussions** in the community.
+  - Contributing to the project's **testing** and quality assurance.
+
+### Junior Maintainer
+
+- **Role**: Less experienced maintainers who work under the supervision of
+  Maintainers or Senior Maintainers. They assist with smaller tasks and learn
+  the process of project maintenance.
+- **Responsibilities**:
+  - Performing **code reviews** and **fixing bugs**, often with guidance from
+    more experienced maintainers.
+  - Assisting with **documentation** and **issue management**.
+  - Submitting minor pull requests and providing assistance to the community.
+  - Actively **learning and developing** under mentorship.
+
+## Current Maintainers
+
+> [!IMPORTANT]
+>
+> At this time, we are **not accepting new Maintainers or Junior Maintainers**.
+> Pull Requests to be added to the maintainer list will not be considered for
+> now. This decision may be revisited in the future.
+
+| Maintainer                                        | Role                |
+| :------------------------------------------------ | :------------------ |
+| [Homelab-Alpha](https://github.com/homelab-alpha) | **Project Founder** |
+
+## Past Maintainers
+
+> [!NOTE]
+>
+> This section will be updated as maintainers leave the project or step down
+> from their role.
+
+| Maintainer | Role |
+| :--------- | :--- |
+
+## Additional Guidelines
+
+### Decision-Making Process
+
+Decisions, especially concerning major changes, features, or maintainer
+appointments, are generally made through **consensus** among the Senior
+Maintainers and the Project Founder. However, the **Project Founder retains the
+ultimate veto right** on all project decisions to ensure alignment with the
+project's long-term vision and strategic direction. This ensures that while
+collaborative decision-making is prioritized, the project's core vision remains
+intact.
+
+### Activity Expectations for Maintainers
+
+To ensure the project remains active and well-maintained, we expect all
+maintainers to show consistent engagement. We propose the following guidelines:
+
+- **Junior Maintainers**: Expected to contribute at least **one meaningful
+  contribution** (e.g., Pull Request review, bugfix, documentation update) per
+  month. This helps in their learning and integration into the team.
+  - A **meaningful contribution** is defined as an action that demonstrably adds
+    value to the project, such as resolving a bug, adding a feature,
+    significantly improving documentation, or providing a detailed and
+    constructive pull request review that leads to improvement.
+
+- **Maintainers**: Expected to contribute at least **two meaningful
+  contributions** (e.g., Pull Request review, feature implementation, issue
+  management) per month.
+- **Senior Maintainers**: Expected to maintain a high level of activity,
+  including **regular in-depth code reviews, active participation in
+  architectural discussions, and mentoring**, with no specific numerical minimum
+  as their contributions are often strategic and less frequent in volume but
+  high in impact.
+
+Should a maintainer become inactive for a period exceeding **three consecutive
+months** without prior communication, the existing Project Founder and Senior
+Maintainers will initiate a review of their role. This review may lead to a
+discussion about their ability to continue in the role or, if necessary, their
+removal from the active maintainer list.
+
+### Stepping Down or Removal of Roles
+
+- **Voluntary Resignation**: If a maintainer wishes to step down, they should
+  notify the Project Founder or a Senior Maintainer **via a formal email**. A
+  formal announcement will then be made to the community.
+- **Involuntary Removal**: In cases of prolonged inactivity (as described above)
+  or violations of community guidelines/[code of conduct], the Project Founder,
+  in consultation with Senior Maintainers, may decide to remove a maintainer.
+  The decision will be communicated privately to the individual first, followed
+  by a general announcement if deemed necessary to inform the community of a
+  change in the active maintainer list.
+
+### Conflict Resolution
+
+Conflicts within the maintainer team are resolved through a structured approach
+to ensure fair and effective outcomes:
+
+- **Open Discussion**: The first step is always an open and respectful
+  discussion among the involved parties to understand all perspectives and find
+  common ground.
+- **Mediation by Senior Maintainer**: If a resolution is not reached, a neutral
+  Senior Maintainer (not directly involved in the conflict) will act as a
+  mediator to facilitate further discussion and guide the team towards a
+  solution.
+- **Project Founder's Decision**: If mediation fails, or in cases of significant
+  disagreement affecting project direction or health, the Project Founder will
+  make the final binding decision, leveraging their veto right as needed. The
+  decision will be communicated clearly to all involved parties.
+
+### Communication Channels
+
+Maintainers primarily communicate via:
+
+- **Email**: For day-to-day discussions, quick updates, and informal
+  problem-solving.
+- **GitHub Issues & Pull Request Comments**: For discussions directly related to
+  code, features, and bugs.
+
+### Contribution Review Frequency
+
+We strive to review and merge contributions promptly, keeping the project moving
+and supporting our contributors.
+
+- **Timely Acknowledgment**: We'll acknowledge new Pull Requests within **5
+  business days** to confirm receipt and provide an initial status.
+- **Active Review**: Maintainers will actively engage in the review process,
+  offering constructive feedback and working toward merging within a reasonable
+  timeframe. While exact times can vary, we generally aim for a complete review
+  cycle (from submission to merge) to be completed within **two weeks** for
+  straightforward contributions. Complex contributions may take longer, and
+  we'll communicate any anticipated delays.
+
+We understand that review times can vary based on contribution complexity and
+current maintainer workload. We're committed to transparent communication if
+delays occur.
+
+### CODEOWNERS File
+
+To ensure that code changes are reviewed by the appropriate maintainers, we
+utilize a [CODEOWNERS] file. This file, located at `.github/CODEOWNERS` in the
+repository, specifies individuals or teams responsible for code in designated
+paths.
+
+Using a `CODEOWNERS` file helps to:
+
+- **Automate Reviews**: Automatically request reviews from the specified code
+  owners when a pull request modifies code in their area of responsibility.
+- **Enforce Ownership**: Clearly define who is responsible for which parts of
+  the codebase.
+- **Streamline Workflow**: Expedite the review process by directing pull
+  requests to the most knowledgeable maintainers.
+
+### Security Considerations
+
+Security is paramount for this project. All maintainers are expected to be aware
+of and adhere to our [Security Policy]. Any reported security vulnerabilities
+will be handled by the **Senior Maintainers** or the **Project Founder** in
+accordance with this policy.
+
+### Project Roadmap
+
+The project's strategic direction and future development are guided by a
+**Project Roadmap**. This roadmap outlines our long-term goals, major features,
+and key initiatives. It serves as a living document, evolving with the needs of
+the project and its community. Senior Maintainers are expected to actively
+contribute to and help shape this roadmap, ensuring it aligns with the project's
+vision.
+
+## Concluding Remarks
+
+We extend our sincere gratitude to all current maintainers for their dedication
+and hard work. Your contributions are invaluable to the progress and success of
+this project.
+
+To everyone considering becoming a Junior Maintainer, thank you for your
+interest! We truly appreciate your desire for deeper involvement in our project.
+While becoming a maintainer is a competitive journey, and we can't accept every
+application to join the Homelab-Alpha team, we firmly believe that all
+contributions enrich our community. We encourage you to keep contributing and
+engaging with us, as every effort helps our project grow and thrive.
+
+[MAINTAINERS]: https://github.com/homelab-alpha/homelab-alpha/blob/main/MAINTAINERS.md#current-maintainers
+[code of conduct]: https://github.com/homelab-alpha/homelab-alpha/blob/main/CODE_OF_CONDUCT.md
+[CODEOWNERS]: https://github.com/homelab-alpha/homelab-alpha/blob/main/.github/CODEOWNERS
+[Security Policy]: https://github.com/homelab-alpha/homelab-alpha/blob/main/SECURITY.md


### PR DESCRIPTION
- Introduced a MAINTAINERS.md file to document maintainer roles,
  responsibilities, and progression.
- Defined the process for becoming a Junior Maintainer and outlined
  promotion criteria for higher roles.
- Clarified governance, decision-making, activity expectations, and
  conflict resolution to improve long-term project sustainability.